### PR TITLE
Allow padding between title text and top of View.

### DIFF
--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -67,5 +67,7 @@
         <attr name="textSize" format="dimension" />
         <!-- Padding between titles when bumping into each other. -->
         <attr name="titlePadding" format="dimension" />
+        <!-- Padding between titles and the top of the View. -->
+        <attr name="topPadding" format="dimension" />
     </declare-styleable>
 </resources>

--- a/library/res/values/defaults.xml
+++ b/library/res/values/defaults.xml
@@ -34,4 +34,5 @@
     <color name="default_title_indicator_text_color">#FFAAAAAA</color>
     <dimen name="default_title_indicator_text_size">18dp</dimen>
     <dimen name="default_title_indicator_title_padding">5dp</dimen>
+    <dimen name="default_title_indicator_top_padding">0dp</dimen>
 </resources>

--- a/library/res/values/styles.xml
+++ b/library/res/values/styles.xml
@@ -42,5 +42,6 @@
         <item name="textColor">@color/default_title_indicator_text_color</item>
         <item name="textSize">@dimen/default_title_indicator_text_size</item>
         <item name="titlePadding">@dimen/default_title_indicator_title_padding</item>
+        <item name="topPadding">@dimen/default_title_indicator_top_padding</item>
     </style>
 </resources>

--- a/library/src/com/jakewharton/android/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/jakewharton/android/viewpagerindicator/TitlePageIndicator.java
@@ -376,8 +376,8 @@ public class TitlePageIndicator extends View implements PageIndicator {
 
         //Draw the footer line
         mPath = new Path();
-        mPath.moveTo(0, height - mFooterLineHeight);
-        mPath.lineTo(width, height - mFooterLineHeight);
+        mPath.moveTo(0, height - mFooterLineHeight / 2f);
+        mPath.lineTo(width, height - mFooterLineHeight / 2f);
         mPath.close();
         canvas.drawPath(mPath, mPaintFooterLine);
 

--- a/library/src/com/jakewharton/android/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/jakewharton/android/viewpagerindicator/TitlePageIndicator.java
@@ -89,6 +89,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
     private float mFooterIndicatorUnderlinePadding;
     private float mFooterPadding;
     private float mTitlePadding;
+    private float mTopPadding;
     /** Left and right side padding for not active view titles. */
     private float mClipPadding;
     private float mFooterLineHeight;
@@ -119,6 +120,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
         final float defaultTextSize = res.getDimension(R.dimen.default_title_indicator_text_size);
         final float defaultTitlePadding = res.getDimension(R.dimen.default_title_indicator_title_padding);
         final float defaultClipPadding = res.getDimension(R.dimen.default_title_indicator_clip_padding);
+        final float defaultTopPadding = res.getDimension(R.dimen.default_title_indicator_top_padding);
 
         //Retrieve styles attributes
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.TitlePageIndicator, defStyle, R.style.Widget_TitlePageIndicator);
@@ -129,6 +131,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
         mFooterIndicatorHeight = a.getDimension(R.styleable.TitlePageIndicator_footerIndicatorHeight, defaultFooterIndicatorHeight);
         mFooterIndicatorUnderlinePadding = a.getDimension(R.styleable.TitlePageIndicator_footerIndicatorUnderlinePadding, defaultFooterIndicatorUnderlinePadding);
         mFooterPadding = a.getDimension(R.styleable.TitlePageIndicator_footerPadding, defaultFooterPadding);
+        mTopPadding = a.getDimension(R.styleable.TitlePageIndicator_topPadding, defaultTopPadding);
         mTitlePadding = a.getDimension(R.styleable.TitlePageIndicator_titlePadding, defaultTitlePadding);
         mClipPadding = a.getDimension(R.styleable.TitlePageIndicator_clipPadding, defaultClipPadding);
         mColorSelected = a.getColor(R.styleable.TitlePageIndicator_selectedColor, defaultSelectedColor);
@@ -244,6 +247,15 @@ public class TitlePageIndicator extends View implements PageIndicator {
         mTitlePadding = titlePadding;
         invalidate();
     }
+    
+    public float getTopPadding() {
+    	return this.mTopPadding;
+    }
+    
+    public void setTopPadding(float topPadding) {
+    	mTopPadding = topPadding;
+    	invalidate();
+    }
 
     public float getClipPadding() {
         return this.mClipPadding;
@@ -351,13 +363,13 @@ public class TitlePageIndicator extends View implements PageIndicator {
 
                 //Draw text as unselected
                 mPaintText.setColor(mColorText);
-                canvas.drawText(mTitleProvider.getTitle(i), bound.left, bound.bottom, mPaintText);
+                canvas.drawText(mTitleProvider.getTitle(i), bound.left, bound.bottom + mTopPadding, mPaintText);
 
                 //If we are within the selected bounds draw the selected text
                 if (currentPage && currentSelected) {
                     mPaintText.setColor(mColorSelected);
                     mPaintText.setAlpha((int)((mColorSelected >>> 24) * selectedPercent));
-                    canvas.drawText(mTitleProvider.getTitle(i), bound.left, bound.bottom, mPaintText);
+                    canvas.drawText(mTitleProvider.getTitle(i), bound.left, bound.bottom + mTopPadding, mPaintText);
                 }
             }
         }
@@ -595,7 +607,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
             //Calculate the text bounds
             RectF bounds = new RectF();
             bounds.bottom = mPaintText.descent()-mPaintText.ascent();
-            result = bounds.bottom - bounds.top + mFooterLineHeight + mFooterPadding;
+            result = bounds.bottom - bounds.top + mFooterLineHeight + mFooterPadding + mTopPadding;
             if (mFooterIndicatorStyle != IndicatorStyle.None) {
                 result += mFooterIndicatorHeight;
             }


### PR DESCRIPTION
This change allows padding between title and top of View to be specified for title page indicator. This is significant if you set the background color of the View and want extra padding to centre the title text.

I also noticed a bug where the footer line wasn't being drawn at the very bottom of the View.
