### PR TITLE
Solution for issue #11 and issue #13

### DIFF
--- a/library/src/com/jakewharton/android/view/CirclePageIndicator.java
+++ b/library/src/com/jakewharton/android/view/CirclePageIndicator.java
@@ -47,6 +47,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
     private int mCurrentPage;
     private int mSnapPage;
     private int mCurrentOffset;
+    private int mScrollState;
     private int mPageSize;
     private int mOrientation;
     private boolean mCentered;
@@ -285,6 +286,8 @@ public class CirclePageIndicator extends View implements PageIndicator {
 
     @Override
     public void onPageScrollStateChanged(int state) {
+        mScrollState = state;
+        
         if (mListener != null) {
             mListener.onPageScrollStateChanged(state);
         }
@@ -304,9 +307,11 @@ public class CirclePageIndicator extends View implements PageIndicator {
 
     @Override
     public void onPageSelected(int position) {
-        mCurrentPage = position;
-        mSnapPage = position;
-        invalidate();
+        if (mSnap || mScrollState == ViewPager.SCROLL_STATE_IDLE) {
+            mCurrentPage = position;
+            mSnapPage = position;
+            invalidate();
+        }
 
         if (mListener != null) {
             mListener.onPageSelected(position);
@@ -316,11 +321,6 @@ public class CirclePageIndicator extends View implements PageIndicator {
     @Override
     public void setOnPageChangeListener(ViewPager.OnPageChangeListener listener) {
         mListener = listener;
-    }
-
-    @Override
-    public void notifyDataSetChanged() {
-        invalidate();
     }
 
     /*

--- a/library/src/com/jakewharton/android/view/PageIndicator.java
+++ b/library/src/com/jakewharton/android/view/PageIndicator.java
@@ -55,10 +55,4 @@ public interface PageIndicator extends ViewPager.OnPageChangeListener {
      * @param listener
      */
     public void setOnPageChangeListener(ViewPager.OnPageChangeListener listener);
-
-    /**
-     * Notify the indicator that the underlying data set has changed and it
-     * should redraw itself to reflect the changes.
-     */
-    public void notifyDataSetChanged();
 }

--- a/library/src/com/jakewharton/android/view/TitlePageIndicator.java
+++ b/library/src/com/jakewharton/android/view/TitlePageIndicator.java
@@ -80,6 +80,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
     private TitleProvider mTitleProvider;
     private int mCurrentPage;
     private int mCurrentOffset;
+    private int mScrollState;
     private final Paint mPaintText;
     private boolean mBoldText;
     private int mColorText;
@@ -534,6 +535,8 @@ public class TitlePageIndicator extends View implements PageIndicator {
 
     @Override
     public void onPageScrollStateChanged(int state) {
+        mScrollState = state;
+        
         if (mListener != null) {
             mListener.onPageScrollStateChanged(state);
         }
@@ -552,6 +555,11 @@ public class TitlePageIndicator extends View implements PageIndicator {
 
     @Override
     public void onPageSelected(int position) {
+        if (mScrollState == ViewPager.SCROLL_STATE_IDLE) {
+            mCurrentPage = position;
+            invalidate();
+        }
+        
         if (mListener != null) {
             mListener.onPageSelected(position);
         }
@@ -560,11 +568,6 @@ public class TitlePageIndicator extends View implements PageIndicator {
     @Override
     public void setOnPageChangeListener(ViewPager.OnPageChangeListener listener) {
         mListener = listener;
-    }
-
-    @Override
-    public void notifyDataSetChanged() {
-        invalidate();
     }
 
     /*


### PR DESCRIPTION
This fixes my issues with TitlePageIndicator not acting on notifyDataSetChanged and onPageSelected causing the CirclePageIndicator to 'jump'

Issue #13:
When the PageIndicator is clicked, so it scrolls from page 0 to page 1, onPageSelected will be called with the target page as position, while onPageScrolled will finish the scroll with the position of the left-most page. This will make the indicator 'jump' if the view was allowed to draw the position from onPageSelected.
An example of this behavior:

```
10-02 17:19:35.051: DEBUG/onPageScrollStateChanged(3950): 2
10-02 17:19:35.051: DEBUG/onPageSelected(3950): 1
10-02 17:19:35.071: DEBUG/onPageScrolled(3950): 0
10-02 17:19:35.081: DEBUG/onPageScrolled(3950): 0
...snip...
10-02 17:19:35.211: DEBUG/onPageScrolled(3950): 0
10-02 17:19:35.231: DEBUG/onPageScrolled(3950): 0
10-02 17:19:35.251: DEBUG/onPageScrolled(3950): 1
10-02 17:19:35.271: DEBUG/onPageScrollStateChanged(3950): 0
```

When scrolling by swiping on the ViewPager, once the user lets go of the screen, onPageSelected will be called the position of the target page, while onPageScrolled will be called for the remainder of the scroll with the position of the left-most page. This will again cause a 'jump' in the indicator.
An example of this behavior:

```
10-02 17:23:47.107: DEBUG/onPageScrollStateChanged(3950): 1
10-02 17:23:47.107: DEBUG/onPageScrolled(3950): 0
10-02 17:23:47.127: DEBUG/onPageScrolled(3950): 0
...snip...
10-02 17:23:47.187: DEBUG/onPageScrolled(3950): 0
10-02 17:23:47.197: DEBUG/onPageScrolled(3950): 0
10-02 17:23:47.217: DEBUG/onPageScrollStateChanged(3950): 2
10-02 17:23:47.217: DEBUG/onPageSelected(3950): 1
10-02 17:23:47.227: DEBUG/onPageScrolled(3950): 0
10-02 17:23:47.247: DEBUG/onPageScrolled(3950): 0
...snip...
10-02 17:23:47.397: DEBUG/onPageScrolled(3950): 0
10-02 17:23:47.407: DEBUG/onPageScrolled(3950): 0
10-02 17:23:47.427: DEBUG/onPageScrolled(3950): 1
10-02 17:23:47.437: DEBUG/onPageScrollStateChanged(3950): 0
```

Issue #11:
When notifyDataSetChanged is called on the PagerAdapter, the ViewPager correctly updates its children. After it has done so, it calls onPageSelected with the new current page position.
Since TitlePagerAdapter does not handle onPageSelected, this would cause it to go out of sync with the ViewPager. This could also cause an indexOutOfBounds exception if the pages were removed, after which the TitlePageIndicator was invalidated, since it had not updated mCurrentPage.

The solution:
OnPageSelectedListener has the callback onPageScrollStateChanged. This can have three states.
SCROLL_STATE_IDLE - When the current page is fully in view
SCROLL_STATE_DRAGGING - When the user is dragging the view
SCROLL_STATE_SETTLING - When the pager is settling a view as the current page

If we save the state from onPageScrollStateChanged, we can check this value in onPageSelected.
onPageSelected should only save current position and invalidate the view if the scroll state is IDLE (or in the case of CirclePageIndicator, if it's set to snap). This will make sure that it does not invalidate the view when dragging or touching the PageIndicator.

Since scroll state is most likely IDLE when we call notifyDataSetChanged on the PagerAdapter, this will also make sure that it acts on onPageSelected when we get the callback from ViewPager.

Let me know if you see any issue with this solution.
