### PR TITLE
Drag ViewPager when dragging TitleIndicator

### DIFF
--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -27,10 +27,13 @@ import android.graphics.Path;
 import android.graphics.RectF;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.v4.view.MotionEventCompat;
+import android.support.v4.view.ViewConfigurationCompat;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
 
 /**
  * A TitlePageIndicator is a PageIndicator which displays the title of left view
@@ -95,6 +98,13 @@ public class TitlePageIndicator extends View implements PageIndicator {
     private float mClipPadding;
     private float mFooterLineHeight;
 
+    private static final int INVALID_POINTER = -1;
+
+    private int mTouchSlop;
+    private float mLastMotionX = -1;
+    private int mActivePointerId = INVALID_POINTER;
+    private boolean mIsDragging;
+
 
     public TitlePageIndicator(Context context) {
         this(context, null);
@@ -151,6 +161,9 @@ public class TitlePageIndicator extends View implements PageIndicator {
         mPaintFooterIndicator = new Paint();
         mPaintFooterIndicator.setStyle(Paint.Style.FILL_AND_STROKE);
         mPaintFooterIndicator.setColor(footerColor);
+
+        final ViewConfiguration configuration = ViewConfiguration.get(context);
+        mTouchSlop = ViewConfigurationCompat.getScaledPagingTouchSlop(configuration);
 
         a.recycle();
     }
@@ -411,26 +424,85 @@ public class TitlePageIndicator extends View implements PageIndicator {
                 break;
         }
     }
+    
+    public boolean onTouchEvent(android.view.MotionEvent ev) {
+        if (mViewPager == null) return false;
 
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        if (event.getAction() == MotionEvent.ACTION_DOWN) {
-            final int count = mViewPager.getAdapter().getCount();
-            final int width = getWidth();
-            final float halfWidth = width / 2f;
-            final float sixthWidth = width / 6f;
+        final int action = ev.getAction();
 
-            if ((mCurrentPage > 0) && (event.getX() < halfWidth - sixthWidth)) {
-                mViewPager.setCurrentItem(mCurrentPage - 1);
-                return true;
-            } else if ((mCurrentPage < count - 1) && (event.getX() > halfWidth + sixthWidth)) {
-                mViewPager.setCurrentItem(mCurrentPage + 1);
-                return true;
+        switch (action & MotionEventCompat.ACTION_MASK) {
+            case MotionEvent.ACTION_DOWN:
+                mActivePointerId = MotionEventCompat.getPointerId(ev, 0);
+                mLastMotionX = ev.getX();
+                break;
+
+            case MotionEvent.ACTION_MOVE: {
+                final int activePointerIndex = MotionEventCompat.findPointerIndex(ev, mActivePointerId);
+                final float x = MotionEventCompat.getX(ev, activePointerIndex);
+                final float deltaX = x - mLastMotionX;
+
+                if (!mIsDragging) {
+                    if (Math.abs(deltaX) > mTouchSlop) {
+                        mIsDragging = true;
+                    }
+                }
+
+                if (mIsDragging) {
+                    if (!mViewPager.isFakeDragging()) {
+                        mViewPager.beginFakeDrag();
+                    }
+
+                    mLastMotionX = x;
+                    
+                    mViewPager.fakeDragBy(deltaX);
+                }
+
+                break;
             }
+
+            case MotionEvent.ACTION_CANCEL:
+            case MotionEvent.ACTION_UP:
+                if (!mIsDragging) {
+                    final int count = mViewPager.getAdapter().getCount();
+                    final int width = getWidth();
+                    final float halfWidth = width / 2f;
+                    final float sixthWidth = width / 6f;
+
+                    if ((mCurrentPage > 0) && (ev.getX() < halfWidth - sixthWidth)) {
+                        mViewPager.setCurrentItem(mCurrentPage - 1);
+                        return true;
+                    } else if ((mCurrentPage < count - 1) && (ev.getX() > halfWidth + sixthWidth)) {
+                        mViewPager.setCurrentItem(mCurrentPage + 1);
+                        return true;
+                    }
+                }
+                
+                mIsDragging = false;
+                mActivePointerId = INVALID_POINTER;
+                if (mViewPager.isFakeDragging()) mViewPager.endFakeDrag();
+                break;
+
+            case MotionEventCompat.ACTION_POINTER_DOWN: {
+                final int index = MotionEventCompat.getActionIndex(ev);
+                final float x = MotionEventCompat.getX(ev, index);
+                mLastMotionX = x;
+                mActivePointerId = MotionEventCompat.getPointerId(ev, index);
+                break;
+            }
+
+            case MotionEventCompat.ACTION_POINTER_UP:
+                final int pointerIndex = MotionEventCompat.getActionIndex(ev);
+                final int pointerId = MotionEventCompat.getPointerId(ev, pointerIndex);
+                if (pointerId == mActivePointerId) {
+                    final int newPointerIndex = pointerIndex == 0 ? 1 : 0;
+                    mActivePointerId = MotionEventCompat.getPointerId(ev, newPointerIndex);
+                }
+                mLastMotionX = MotionEventCompat.getX(ev, MotionEventCompat.findPointerIndex(ev, mActivePointerId));
+                break;
         }
 
-        return super.onTouchEvent(event);
-    }
+        return true;
+    };
 
     /**
      * Set bounds for the right textView including clip padding.


### PR DESCRIPTION
What the title says. Using the new fakedrag stuff in ViewPager.

The onTouchEvent code is pretty much copied from ViewPager, so it behaves the same, although fakedrag reacts a bit differently when near edges than the normal ViewPager dragging.

I only did it for the TitlePageIndicator, since the DirectionalViewPager sample kept crashing for me, and you probably have to do your own implementation of fakedrag.
