### PR TITLE
Filled circles (Page Colour)

### DIFF
--- a/library/res/values/vpi__attrs.xml
+++ b/library/res/values/vpi__attrs.xml
@@ -34,6 +34,8 @@
         <attr name="centered" format="boolean" />
         <!-- Color of the filled circle that represents the current page. -->
         <attr name="fillColor" format="color" />
+        <!-- Color of the filled circles that represents pages. -->
+        <attr name="pageColor" format="color" />
         <!-- Orientation of the indicator. -->
         <attr name="orientation">
             <enum name="horizontal" value="0" />

--- a/library/res/values/vpi__defaults.xml
+++ b/library/res/values/vpi__defaults.xml
@@ -17,6 +17,7 @@
 <resources>
     <bool name="default_circle_indicator_centered">true</bool>
     <color name="default_circle_indicator_fill_color">#FFFFFFFF</color>
+    <color name="default_circle_indicator_page_color">#00000000</color>
     <integer name="default_circle_indicator_orientation">0</integer>
     <dimen name="default_circle_indicator_radius">3dp</dimen>
     <bool name="default_circle_indicator_snap">false</bool>

--- a/library/res/values/vpi__styles.xml
+++ b/library/res/values/vpi__styles.xml
@@ -27,6 +27,7 @@
     <style name="Widget.CirclePageIndicator" parent="Widget">
         <item name="centered">@bool/default_circle_indicator_centered</item>
         <item name="fillColor">@color/default_circle_indicator_fill_color</item>
+        <item name="pageColor">@color/default_circle_indicator_page_color</item>
         <item name="orientation">@integer/default_circle_indicator_orientation</item>
         <item name="radius">@dimen/default_circle_indicator_radius</item>
         <item name="snap">@bool/default_circle_indicator_snap</item>

--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -41,6 +41,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
     public static final int VERTICAL = 1;
 
     private float mRadius;
+    private final Paint mPaintPageFill;
     private final Paint mPaintStroke;
     private final Paint mPaintFill;
     private ViewPager mViewPager;
@@ -75,6 +76,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
 
         //Load defaults from resources
         final Resources res = getResources();
+        final int defaultPageColor = res.getColor(R.color.default_circle_indicator_page_color);
         final int defaultFillColor = res.getColor(R.color.default_circle_indicator_fill_color);
         final int defaultOrientation = res.getInteger(R.integer.default_circle_indicator_orientation);
         final int defaultStrokeColor = res.getColor(R.color.default_circle_indicator_stroke_color);
@@ -88,6 +90,9 @@ public class CirclePageIndicator extends View implements PageIndicator {
 
         mCentered = a.getBoolean(R.styleable.CirclePageIndicator_centered, defaultCentered);
         mOrientation = a.getInt(R.styleable.CirclePageIndicator_orientation, defaultOrientation);
+        mPaintPageFill = new Paint(Paint.ANTI_ALIAS_FLAG);
+        mPaintPageFill.setStyle(Style.FILL);
+        mPaintPageFill.setColor(a.getColor(R.styleable.CirclePageIndicator_pageColor, defaultPageColor));
         mPaintStroke = new Paint(Paint.ANTI_ALIAS_FLAG);
         mPaintStroke.setStyle(Style.STROKE);
         mPaintStroke.setColor(a.getColor(R.styleable.CirclePageIndicator_strokeColor, defaultStrokeColor));
@@ -112,6 +117,15 @@ public class CirclePageIndicator extends View implements PageIndicator {
 
     public boolean isCentered() {
         return mCentered;
+    }
+
+    public void setPageColor(int pageColor) {
+        mPaintPageFill.setColor(pageColor);
+        invalidate();
+    }
+
+    public int getPageColor() {
+        return mPaintPageFill.getColor();
     }
 
     public void setFillColor(int fillColor) {
@@ -220,6 +234,11 @@ public class CirclePageIndicator extends View implements PageIndicator {
         float dX;
         float dY;
 
+        float pageFillRadius = mRadius;
+        if (mPaintStroke.getStrokeWidth() > 0) {
+            pageFillRadius -= mPaintStroke.getStrokeWidth() / 2.0f;
+        }
+
         //Draw stroked circles
         for (int iLoop = 0; iLoop < count; iLoop++) {
             float drawLong = longOffset + (iLoop * threeRadius);
@@ -230,7 +249,15 @@ public class CirclePageIndicator extends View implements PageIndicator {
                 dX = shortOffset;
                 dY = drawLong;
             }
-            canvas.drawCircle(dX, dY, mRadius, mPaintStroke);
+            // Only paint fill if not completely transparent
+            if (mPaintPageFill.getAlpha() > 0) {
+                canvas.drawCircle(dX, dY, pageFillRadius, mPaintPageFill);
+            }
+
+            // Only paint stroke if a stroke width was non-zero
+            if (pageFillRadius != mRadius) {
+                canvas.drawCircle(dX, dY, mRadius, mPaintStroke);
+            }
         }
 
         //Draw the filled circle according to the current scroll

--- a/sample/res/layout/themed_circles.xml
+++ b/sample/res/layout/themed_circles.xml
@@ -35,6 +35,7 @@
         android:background="#FFCCCCCC"
         app:radius="10dp"
         app:fillColor="#FF888888"
+        app:pageColor="#88FF0000"
         app:strokeColor="#FF000000"
         app:strokeWidth="2dp"
         />

--- a/sample/src/com/viewpagerindicator/sample/SampleCirclesStyledMethods.java
+++ b/sample/src/com/viewpagerindicator/sample/SampleCirclesStyledMethods.java
@@ -23,6 +23,7 @@ public class SampleCirclesStyledMethods extends BaseSampleActivity {
 		final float density = getResources().getDisplayMetrics().density;
 		indicator.setBackgroundColor(0xFFCCCCCC);
 		indicator.setRadius(10 * density);
+        indicator.setPageColor(0x880000FF);
 		indicator.setFillColor(0xFF888888);
 		indicator.setStrokeColor(0xFF000000);
 		indicator.setStrokeWidth(2 * density);


### PR DESCRIPTION
Hi Jake,

This might be useful for you and/or others.. allowing the non-active page to be a filled colour. (Defaults to transparent for compatibility with previous versions)

If this is something you're prepared to merge, I'm happy to fix it until you're happy with it.

Rob.
# 

Allow the circular indicator to have a specified fill colour for the page circles.
- "pageColor" colour attribute
- defaulted to transparent
- calculate draw radius by removing stroke if non-zero
- skip drawing if transparent
- skip stroke paint if zero width
- examples in "Styled (via layout)" and "Styled (via methods)"
