### PR TITLE
Fixed orientation issue

### DIFF
--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -92,7 +92,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
     private ViewPager mViewPager;
     private ViewPager.OnPageChangeListener mListener;
     private TitleProvider mTitleProvider;
-    private int mCurrentPage;
+    private int mCurrentPage = -1;
     private int mCurrentOffset;
     private int mScrollState;
     private final Paint mPaintText = new Paint();
@@ -319,6 +319,9 @@ public class TitlePageIndicator extends View implements PageIndicator {
             return;
         }
 
+        // mCurrentPage is -1 on first start and after orientation changed. If so, retrieve the correct index from viewpager.
+        if(mCurrentPage == -1 && mViewPager != null) mCurrentPage = mViewPager.getCurrentItem();
+        
         //Calculate views bounds
         ArrayList<RectF> bounds = calculateAllBounds(mPaintText);
         final int boundsSize = bounds.size();


### PR DESCRIPTION
This patch will fix an orientation change issue. Before this patch, after rotating the device, the VPI thought that his current position was 0, so it drew the wrong Titles. 
For my configuration, onSaveInstanceState was not called(I guess because of android:configChanges="orientation"). 

I tested it in my app and it works. I hope this also fixes issue #54, but I couldn't reproduce that issue. 
