### PR TITLE
Orientationpatch

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.viewpagerindicator</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.3</version>
+		<version>2.2.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -92,7 +92,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
     private ViewPager mViewPager;
     private ViewPager.OnPageChangeListener mListener;
     private TitleProvider mTitleProvider;
-    private int mCurrentPage;
+    private int mCurrentPage = -1;
     private int mCurrentOffset;
     private int mScrollState;
     private final Paint mPaintText = new Paint();
@@ -319,6 +319,9 @@ public class TitlePageIndicator extends View implements PageIndicator {
             return;
         }
 
+        // mCurrentPage is -1 on first start and after orientation changed. If so, retrieve the correct index from viewpager.
+        if(mCurrentPage == -1 && mViewPager != null) mCurrentPage = mViewPager.getCurrentItem();
+        
         //Calculate views bounds
         ArrayList<RectF> bounds = calculateAllBounds(mPaintText);
         final int boundsSize = bounds.size();

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.viewpagerindicator</groupId>
 	<artifactId>parent</artifactId>
 	<packaging>pom</packaging>
-	<version>2.2.3</version>
+	<version>2.2.4-SNAPSHOT</version>
 
 	<name>Android-ViewPagerIndicator (Parent)</name>
 	<description>Android library for.</description>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.viewpagerindicator</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.3</version>
+		<version>2.2.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
Ok, here's a new version of the orientation change patch. 
After an orientation-change, the field mCurrentPage is reset to -1. If it's -1 in the onDraw-method, it'll retrieve the currentPage from the viewpager. 

This should work on any API level. Might fix #54. 

EDIT: Forgot to set your repository to dev, sorry.
