### PR TITLE
Just added a fix to setCurrent item for TabPageIndicator

### DIFF
--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -196,6 +196,8 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
             throw new IllegalStateException("ViewPager has not been bound.");
         }
         mSelectedTabIndex = item;
+        mViewPager.setCurrentItem(item);
+        
         final int tabCount = mTabLayout.getChildCount();
         for (int i = 0; i < tabCount; i++) {
             final View child = mTabLayout.getChildAt(i);


### PR DESCRIPTION
Previously, tabpageindicator doesn't change the bounded viewpager's currentitem. This can caused the viewpager to be out of sync with the tabpageindicator if the user set the current item manually.
