### PR TITLE
Fix for lost content in sample app

### DIFF
--- a/sample/src/com/viewpagerindicator/sample/TestFragment.java
+++ b/sample/src/com/viewpagerindicator/sample/TestFragment.java
@@ -27,13 +27,18 @@ public final class TestFragment extends Fragment {
 	}
 	
 	private String mContent = "???";
-	
+
 	@Override
-	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
 		if ((savedInstanceState != null) && savedInstanceState.containsKey(KEY_CONTENT)) {
 			mContent = savedInstanceState.getString(KEY_CONTENT);
 		}
-		
+	}
+	
+	@Override
+	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		TextView text = new TextView(getActivity());
 		text.setGravity(Gravity.CENTER);
 		text.setText(mContent);


### PR DESCRIPTION
onCreateView is not the correct place to restore the tab content because it is not guaranteed to be called. For example, if the user opens the app, swipes through all of the tabs, rotates the device twice, then swipes though the tabs again, the content of some tabs will have been lost, resulting in the user seeing "???". Moving the content restore to onCreate, which is always called after a rotation, will prevent the content from being lost.
