### PR TITLE
New feature: TitleBarIndicator can now split titles around their center

### DIFF
--- a/library/res/values/vpi__attrs.xml
+++ b/library/res/values/vpi__attrs.xml
@@ -69,6 +69,9 @@
     </declare-styleable>
 
     <declare-styleable name="TitlePageIndicator">
+        <!-- Clips titles around their center point. This is useful if you don't know in advance -->
+        <!-- how long your titles are going to be. -->
+        <attr name="clipToCenter" format="boolean" />
         <!-- Screen edge padding. -->
         <attr name="clipPadding" format="dimension" />
         <!-- Color of the footer line and indicator. -->

--- a/library/res/values/vpi__attrs.xml
+++ b/library/res/values/vpi__attrs.xml
@@ -102,6 +102,8 @@
         <attr name="titlePadding" format="dimension" />
         <!-- Padding between titles and the top of the View. -->
         <attr name="topPadding" format="dimension" />
+        <!-- Strength of the fading edge effect. Must be a value between 0.0 and 1.0. -->
+        <attr name="fadingEdgeStrength" format="float" />
     </declare-styleable>
 
     <declare-styleable name="UnderlinePageIndicator">

--- a/library/res/values/vpi__defaults.xml
+++ b/library/res/values/vpi__defaults.xml
@@ -31,6 +31,7 @@
     <color name="default_line_indicator_unselected_color">#FFBBBBBB</color>
     <bool name="default_line_indicator_centered">true</bool>
 
+    <bool name="default_title_indicator_clip_to_center">false</bool>
     <dimen name="default_title_indicator_clip_padding">4dp</dimen>
     <color name="default_title_indicator_footer_color">#FF33B5E5</color>
     <dimen name="default_title_indicator_footer_line_height">2dp</dimen>

--- a/library/res/values/vpi__defaults.xml
+++ b/library/res/values/vpi__defaults.xml
@@ -45,6 +45,7 @@
     <dimen name="default_title_indicator_text_size">15dp</dimen>
     <dimen name="default_title_indicator_title_padding">5dp</dimen>
     <dimen name="default_title_indicator_top_padding">7dp</dimen>
+    <item name="default_title_indicator_fading_edge_strength" type="attr">1.0</item>
 
     <bool name="default_underline_indicator_fades">true</bool>
     <integer name="default_underline_indicator_fade_delay">300</integer>

--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -33,6 +33,7 @@ import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewConfigurationCompat;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -118,6 +119,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
     private float mClipPadding;
     private float mFooterLineHeight;
     private boolean mClipToCenter;
+    private float mFadingEdgeStrength;
 
     private static final int INVALID_POINTER = -1;
 
@@ -157,6 +159,9 @@ public class TitlePageIndicator extends View implements PageIndicator {
         final boolean defaultClipToCenter = res.getBoolean(R.bool.default_title_indicator_clip_to_center);
         final float defaultClipPadding = res.getDimension(R.dimen.default_title_indicator_clip_padding);
         final float defaultTopPadding = res.getDimension(R.dimen.default_title_indicator_top_padding);
+        TypedValue fadingEdgeStrengthTV = new TypedValue();
+        res.getValue(R.attr.default_title_indicator_fading_edge_strength, fadingEdgeStrengthTV, false);
+        final float defaultFadingEdgeStrength = fadingEdgeStrengthTV.getFloat();
 
         //Retrieve styles attributes
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.TitlePageIndicator, defStyle, 0);
@@ -174,6 +179,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
         mColorSelected = a.getColor(R.styleable.TitlePageIndicator_selectedColor, defaultSelectedColor);
         mColorText = a.getColor(R.styleable.TitlePageIndicator_android_textColor, defaultTextColor);
         mBoldText = a.getBoolean(R.styleable.TitlePageIndicator_selectedBold, defaultSelectedBold);
+        mFadingEdgeStrength = a.getFloat(R.styleable.TitlePageIndicator_fadingEdgeStrength, defaultFadingEdgeStrength);
 
         final float textSize = a.getDimension(R.styleable.TitlePageIndicator_android_textSize, defaultTextSize);
         final int footerColor = a.getColor(R.styleable.TitlePageIndicator_footerColor, defaultFooterColor);
@@ -189,6 +195,10 @@ public class TitlePageIndicator extends View implements PageIndicator {
 
         final ViewConfiguration configuration = ViewConfiguration.get(context);
         mTouchSlop = ViewConfigurationCompat.getScaledPagingTouchSlop(configuration);
+
+        // reset view paddings, since this can break the fading edges effect,
+        // and we don't have child views anyway
+        setPadding(0, 0, 0, 0);
     }
 
 
@@ -852,5 +862,15 @@ public class TitlePageIndicator extends View implements PageIndicator {
             title = EMPTY_TITLE;
         }
         return title.toString();
+    }
+
+    @Override
+    protected float getLeftFadingEdgeStrength() {
+        return mFadingEdgeStrength;
+    }
+
+    @Override
+    protected float getRightFadingEdgeStrength() {
+        return mFadingEdgeStrength;
     }
 }


### PR DESCRIPTION
New attribute clipToCenter[BOOL] makes titles in TitlePageIndicator split around their center point.

This is useful if you don't know in advance how long your page labels are going to be, or if you have long titles that constantly bump into one another.

First commit contains all the feature changes. The second commit contains a code refactoring, since I found onDraw was barely legible anymore.

Tested on Nexus One and Galaxy Nexus.

I couldn't add a sample Activity, since the sample app doesn't compile for me. I think I opened an issue for that already.
