### PR TITLE
Fix TitlePageIndicator for long titles

### DIFF
--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -341,7 +341,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
 
         final int countMinusOne = count - 1;
         final float halfWidth = getWidth() / 2f;
-        final int left = getLeft();
+        final int left = 0;//getLeft();
         final float leftClip = left + mClipPadding;
         final int width = getWidth();
         final int height = getHeight();
@@ -366,10 +366,29 @@ public class TitlePageIndicator extends View implements PageIndicator {
         if (curPageBound.left < leftClip) {
             //Try to clip to the screen (left side)
             clipViewOnTheLeft(curPageBound, curPageWidth, left);
+
+            if (mCurrentPage + 1 < bounds.size()) {
+	            //Except if there's an intersection with the right view
+	            Rect rightBound = bounds.get(mCurrentPage + 1);
+	            //Intersection
+	            if (curPageBound.right + mTitlePadding > rightBound.left) {
+	            	curPageBound.left = (int) (rightBound.left - curPageWidth - mTitlePadding);
+	            	curPageBound.right = (int) (curPageBound.left + curPageWidth);
+	            }
+            }
         }
         if (curPageBound.right > rightClip) {
             //Try to clip to the screen (right side)
             clipViewOnTheRight(curPageBound, curPageWidth, right);
+            if (mCurrentPage > 0) {
+	            //Except if there's an intersection with the left view
+	            Rect leftBound = bounds.get(mCurrentPage - 1);
+	            //Intersection
+	            if (curPageBound.left - mTitlePadding < leftBound.right) {
+	            	curPageBound.left = (int) (leftBound.right + mTitlePadding);
+	            	curPageBound.right = (int) (curPageBound.left + curPageWidth);
+	            }
+            }
         }
 
         //Left views starting from the current position


### PR DESCRIPTION
With long titles, the titles would snap from one position to another because the logic for checking for intersecting titles didn't apply to the current page title.

Another change has the onDraw method reference left from 0 instead of getLeft because getLeft causes the long-title intersection calculations to be incorrect if the title indicator doesn't take up the entire width of the screen.
