### PR TITLE
title.toString() drops the spans in a abstract CharSequence

### DIFF
--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -800,6 +800,6 @@ public class TitlePageIndicator extends View implements PageIndicator {
         if (title == null) {
             title = EMPTY_TITLE;
         }
-        return title.toString();
+        return title;
     }
 }


### PR DESCRIPTION
You're using a `CharSequence` to generate the page titles now with `getPageTitle(...)` but the method is returning `title.toString()` instead of `title` which is already a `CharSequence`. I believe simply removing the `toString()` should allow spans set in the `getPageTitle(...)` `CharSequence` to propagate. 
