### PR TITLE
Added ignore for command line build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ classes
 target
 release.properties
 pom.xml.*
+
+#Command line
+local.properties
+build.xml
+proguard-project.txt


### PR DESCRIPTION
This is just to stop the untracked files git message when using this library from the command line ant build system
