### PR TITLE
Icon-only tab indicator implementation

### DIFF
--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -24,6 +24,7 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.HorizontalScrollView;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -150,17 +151,27 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
     }
 
     private void addTab(int index, CharSequence text, int iconResId) {
-        final TabView tabView = new TabView(getContext());
-        tabView.mIndex = index;
-        tabView.setFocusable(true);
-        tabView.setOnClickListener(mTabClickListener);
-        tabView.setText(text);
+        if(text.length() > 0 || iconResId == 0){
+            final TabView tabView = new TabView(getContext());
+            tabView.mIndex = index;
+            tabView.setFocusable(true);
+            tabView.setOnClickListener(mTabClickListener);
+            tabView.setText(text);
 
-        if (iconResId != 0) {
-            tabView.setCompoundDrawablesWithIntrinsicBounds(iconResId, 0, 0, 0);
+            if (iconResId != 0) {
+                tabView.setCompoundDrawablesWithIntrinsicBounds(iconResId, 0, 0, 0);
+            }
+
+            mTabLayout.addView(tabView, new LinearLayout.LayoutParams(0, MATCH_PARENT, 1));
+        } else {
+            final IconTabView tabView = new IconTabView(getContext());
+            tabView.mIndex = index;
+            tabView.setFocusable(true);
+            tabView.setOnClickListener(mTabClickListener);
+            tabView.setImageResource(iconResId);
+
+            mTabLayout.addView(tabView, new LinearLayout.LayoutParams(0, MATCH_PARENT, 1));
         }
-
-        mTabLayout.addView(tabView, new LinearLayout.LayoutParams(0, MATCH_PARENT, 1));
     }
 
     @Override
@@ -262,6 +273,29 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
         private int mIndex;
 
         public TabView(Context context) {
+            super(context, null, R.attr.vpiTabPageIndicatorStyle);
+        }
+
+        @Override
+        public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+            // Re-measure if we went beyond our maximum size.
+            if (mMaxTabWidth > 0 && getMeasuredWidth() > mMaxTabWidth) {
+                super.onMeasure(MeasureSpec.makeMeasureSpec(mMaxTabWidth, MeasureSpec.EXACTLY),
+                        heightMeasureSpec);
+            }
+        }
+
+        public int getIndex() {
+            return mIndex;
+        }
+    }
+
+    private class IconTabView extends ImageView {
+        private int mIndex;
+
+        public IconTabView(Context context) {
             super(context, null, R.attr.vpiTabPageIndicatorStyle);
         }
 

--- a/sample/AndroidManifest.xml
+++ b/sample/AndroidManifest.xml
@@ -246,6 +246,15 @@
           <category android:name="com.jakewharton.android.viewpagerindicator.sample.SAMPLE" />
         </intent-filter>
       </activity>
+      <activity
+          android:name=".SampleTabsOnlyIcons"
+          android:label="Tabs/With Icons Only"
+          android:theme="@style/StyledIndicators">
+        <intent-filter>
+          <action android:name="android.intent.action.MAIN" />
+          <category android:name="com.jakewharton.android.viewpagerindicator.sample.SAMPLE" />
+        </intent-filter>
+      </activity>
 
 
 

--- a/sample/src/com/viewpagerindicator/sample/SampleTabsOnlyIcons.java
+++ b/sample/src/com/viewpagerindicator/sample/SampleTabsOnlyIcons.java
@@ -1,0 +1,60 @@
+package com.viewpagerindicator.sample;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+import com.viewpagerindicator.IconPagerAdapter;
+import com.viewpagerindicator.TabPageIndicator;
+
+public class SampleTabsOnlyIcons extends FragmentActivity {
+    private static final String[] CONTENT = new String[] { "Calendar", "Camera", "Alarms", "Location" };
+    private static final int[] ICONS = new int[] {
+            R.drawable.perm_group_calendar,
+            R.drawable.perm_group_camera,
+            R.drawable.perm_group_device_alarms,
+            R.drawable.perm_group_location,
+    };
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.simple_tabs);
+
+        FragmentPagerAdapter adapter = new GoogleMusicAdapter(getSupportFragmentManager());
+
+        ViewPager pager = (ViewPager) findViewById(R.id.pager);
+        pager.setAdapter(adapter);
+
+        TabPageIndicator indicator =  (TabPageIndicator) findViewById(R.id.indicator);
+        indicator.setViewPager(pager);
+    }
+
+    class GoogleMusicAdapter extends FragmentPagerAdapter implements IconPagerAdapter {
+        public GoogleMusicAdapter(FragmentManager fm) {
+            super(fm);
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            return TestFragment.newInstance(CONTENT[position % CONTENT.length]);
+        }
+
+        @Override
+        public String getPageTitle(int position) {
+            return "";
+        }
+
+        @Override
+        public int getIconResId(int index) {
+            return ICONS[index % ICONS.length];
+        }
+
+        @Override
+        public int getCount() {
+            return ICONS.length;
+        }
+    }
+}


### PR DESCRIPTION
If you have no text for your tab indicator, the icons still show up offset to the left. I thought it might be nice to have an option to have the icon show up centered as an ImageView instead of in a TextView as a left compound drawable.
- Add icon-only version to samples
- Add IconTabView to TabPageIndicator
- Add IconTabView to indicator
  instead of a TabView if there is no text
  but an icon resource is
  provided.
