### PR TITLE
Fix setting background style in PageIndicators

### DIFF
--- a/library/src/com/viewpagerindicator/LinePageIndicator.java
+++ b/library/src/com/viewpagerindicator/LinePageIndicator.java
@@ -86,7 +86,7 @@ public class LinePageIndicator extends View implements PageIndicator {
         mPaintUnselected.setColor(a.getColor(R.styleable.LinePageIndicator_unselectedColor, defaultUnselectedColor));
         mPaintSelected.setColor(a.getColor(R.styleable.LinePageIndicator_selectedColor, defaultSelectedColor));
 
-        Drawable background = a.getDrawable(R.styleable.CirclePageIndicator_android_background);
+        Drawable background = a.getDrawable(R.styleable.LinePageIndicator_android_background);
         if (background != null) {
           setBackgroundDrawable(background);
         }

--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -204,7 +204,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
         mPaintFooterIndicator.setStyle(Paint.Style.FILL_AND_STROKE);
         mPaintFooterIndicator.setColor(footerColor);
 
-        Drawable background = a.getDrawable(R.styleable.CirclePageIndicator_android_background);
+        Drawable background = a.getDrawable(R.styleable.TitlePageIndicator_android_background);
         if (background != null) {
           setBackgroundDrawable(background);
         }

--- a/library/src/com/viewpagerindicator/UnderlinePageIndicator.java
+++ b/library/src/com/viewpagerindicator/UnderlinePageIndicator.java
@@ -98,7 +98,7 @@ public class UnderlinePageIndicator extends View implements PageIndicator {
         setFadeDelay(a.getInteger(R.styleable.UnderlinePageIndicator_fadeDelay, defaultFadeDelay));
         setFadeLength(a.getInteger(R.styleable.UnderlinePageIndicator_fadeLength, defaultFadeLength));
 
-        Drawable background = a.getDrawable(R.styleable.CirclePageIndicator_android_background);
+        Drawable background = a.getDrawable(R.styleable.UnderlinePageIndicator_android_background);
         if (background != null) {
           setBackgroundDrawable(background);
         }


### PR DESCRIPTION
CirclePageIndicator_android_background was being called to set the
background in LinePageIndicator, TitlePageIndicator and
UnderlinePageIndicator which resulted in being unable to set the
background color/drawable correctly.

See issue 117
