### PR TITLE
removed android-support-v4.jar from apklib

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -35,6 +35,9 @@
 				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 				<extensions>true</extensions>
+				<configuration>
+					<nativeLibrariesDirectory>ignored</nativeLibrariesDirectory>
+				</configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
android-support-v4.jar from libs folder makes problems in Idea IDE. It's unnecessary for projects using maven, so can be safely removed from apklib package
It's the same thing as in https://github.com/JakeWharton/ActionBarSherlock/pull/528
