### PR TITLE
Adds an icon-only version of the TabPageIndicator

### DIFF
--- a/sample/AndroidManifest.xml
+++ b/sample/AndroidManifest.xml
@@ -229,6 +229,15 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".SampleTabsIconOnly"
+            android:label="Tabs/Icon Only"
+            android:theme="@style/Theme.PageIndicatorDefaults">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.jakewharton.android.viewpagerindicator.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".SampleTabsStyled"
             android:label="Tabs/Styled"
             android:theme="@style/StyledIndicators">

--- a/sample/src/com/viewpagerindicator/sample/SampleTabsIconOnly.java
+++ b/sample/src/com/viewpagerindicator/sample/SampleTabsIconOnly.java
@@ -1,0 +1,60 @@
+package com.viewpagerindicator.sample;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+
+import com.viewpagerindicator.IconPagerAdapter;
+import com.viewpagerindicator.TabPageIndicator;
+
+public class SampleTabsIconOnly extends FragmentActivity {
+    private static final int[] ICONS = new int[] {
+        R.drawable.perm_group_calendar,
+        R.drawable.perm_group_camera,
+        R.drawable.perm_group_device_alarms,
+        R.drawable.perm_group_location
+    };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.simple_tabs);
+
+        FragmentPagerAdapter adapter = new GoogleMusicAdapter(getSupportFragmentManager());
+
+        ViewPager pager = (ViewPager)findViewById(R.id.pager);
+        pager.setAdapter(adapter);
+
+        TabPageIndicator indicator = (TabPageIndicator)findViewById(R.id.indicator);
+        indicator.setViewPager(pager);
+    }
+
+    class GoogleMusicAdapter extends FragmentPagerAdapter implements IconPagerAdapter {
+        public GoogleMusicAdapter(FragmentManager fm) {
+            super(fm);
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            return TestFragment.newInstance(getResources().getResourceEntryName(ICONS[position % ICONS.length]));
+        }
+
+        @Override
+        public CharSequence getPageTitle(int position) {
+            return null;
+        }
+
+        @Override
+        public int getCount() {
+          return ICONS.length;
+        }
+
+		@Override
+		public int getIconResId(int index) {
+			return ICONS[index % ICONS.length];
+		}
+    }
+}


### PR DESCRIPTION
I added the ability in TabPageIndicator to use a centered icon in the case where a null or empty title is provided by FragmentPagerAdapter and a resource id is supplied by getIconResId (from IconPagerAdapter interface).  This includes a new sample Activity in the Tabs section (Tabs/Icon Only)
![device-2013-01-16-150013](https://f.cloud.github.com/assets/938732/73108/8488d45e-6030-11e2-91dd-a87ad845d730.png)
![device-2013-01-16-150020](https://f.cloud.github.com/assets/938732/73109/848a57f2-6030-11e2-8fb2-711d1c6b639c.png)
