### PR TITLE
Adds an icon-only version of the TabPageIndicator

### DIFF
--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -16,8 +16,6 @@
  */
 package com.viewpagerindicator;
 
-import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
-import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 import android.content.Context;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
@@ -29,6 +27,9 @@ import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
 /**
  * This widget implements the dynamic action bar tab behavior that can change
@@ -151,8 +152,7 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
     }
 
     private void addTab(int index, CharSequence text, int iconResId) {
-        final TabView tabView = new TabView(getContext(), index, text, iconResId);
-
+        TabView tabView = new TabView(getContext(), index, text, iconResId);
         mTabLayout.addView(tabView.getView(), new LinearLayout.LayoutParams(0, MATCH_PARENT, 1));
     }
 
@@ -253,41 +253,37 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
 
     private class TabView {
         private View mView;
-
-        public TabView(Context context, int index, CharSequence text, int iconResId) {
-        	
-        	// If we have an icon and no text, use TabImageView
+        public TabView(Context context, int index, CharSequence text, int iconResId) {        	
+            // If we have an icon and no text, use TabImageView
         	if(iconResId != 0 && (text == null || text.length() == 0)) {
-        		mView = new TabImageView(context, null, R.attr.vpiTabPageIndicatorStyle);
-        		((TabImageView) mView).setImageResource(iconResId);        		
-        	}
-        	else {
-        		mView = new TabTextView(context, null, R.attr.vpiTabPageIndicatorStyle);
-        		((TabTextView) mView).setText(text);        		
-        		if (iconResId != 0) {
-        			((TabTextView) mView).setCompoundDrawablesWithIntrinsicBounds(iconResId, 0, 0, 0);
-        		}
-        	}
-        	mView.setTag(index);
-        	mView.setOnClickListener(mTabClickListener);
-        	mView.setFocusable(true);
+        	    mView = new TabImageView(context, null, R.attr.vpiTabPageIndicatorStyle);
+        	    ((TabImageView) mView).setImageResource(iconResId);        		
+        	} else {
+                mView = new TabTextView(context, null, R.attr.vpiTabPageIndicatorStyle);
+                ((TabTextView) mView).setText(text);        		
+                if (iconResId != 0) {
+                    ((TabTextView) mView).setCompoundDrawablesWithIntrinsicBounds(iconResId, 0, 0, 0);
+                }
+            }
+            mView.setTag(index);
+            mView.setOnClickListener(mTabClickListener);
+            mView.setFocusable(true);
         }
         
         public View getView() {
-        	return mView;
+            return mView;
         }
     }
     
     private class TabTextView extends TextView {
 
 		public TabTextView(Context context, AttributeSet attrs, int defStyle) {
-			super(context, attrs, defStyle);
+		    super(context, attrs, defStyle);
 		}
 
 		@Override
         public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-
             // Re-measure if we went beyond our maximum size.
             if (mMaxTabWidth > 0 && getMeasuredWidth() > mMaxTabWidth) {
                 super.onMeasure(MeasureSpec.makeMeasureSpec(mMaxTabWidth, MeasureSpec.EXACTLY),
@@ -305,7 +301,6 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
 		@Override
         public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-
             // Re-measure if we went beyond our maximum size.
             if (mMaxTabWidth > 0 && getMeasuredWidth() > mMaxTabWidth) {
                 super.onMeasure(MeasureSpec.makeMeasureSpec(mMaxTabWidth, MeasureSpec.EXACTLY),

--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -253,14 +253,14 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
 
     private class TabView {
         private View mView;
-        public TabView(Context context, int index, CharSequence text, int iconResId) {        	
+        public TabView(Context context, int index, CharSequence text, int iconResId) {
             // If we have an icon and no text, use TabImageView
         	if(iconResId != 0 && (text == null || text.length() == 0)) {
         	    mView = new TabImageView(context, null, R.attr.vpiTabPageIndicatorStyle);
-        	    ((TabImageView) mView).setImageResource(iconResId);        		
+        	    ((TabImageView) mView).setImageResource(iconResId);
         	} else {
                 mView = new TabTextView(context, null, R.attr.vpiTabPageIndicatorStyle);
-                ((TabTextView) mView).setText(text);        		
+                ((TabTextView) mView).setText(text);
                 if (iconResId != 0) {
                     ((TabTextView) mView).setCompoundDrawablesWithIntrinsicBounds(iconResId, 0, 0, 0);
                 }

--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -55,7 +55,8 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
 
     private final OnClickListener mTabClickListener = new OnClickListener() {
         public void onClick(View view) {
-            final int oldSelected = mViewPager.getCurrentItem();            
+            final int oldSelected = mViewPager.getCurrentItem();
+
             // The View that was clicked is now a child of the TabView object
             // so the tab's index is stored in the tag property
             final int newSelected = (Integer) view.getTag();
@@ -253,11 +254,13 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
 
     private class TabView {
         private View mView;
+
         public TabView(Context context, int index, CharSequence text, int iconResId) {
+
             // If we have an icon and no text, use TabImageView
-        	if(iconResId != 0 && (text == null || text.length() == 0)) {
-        	    mView = new TabImageView(context, null, R.attr.vpiTabPageIndicatorStyle);
-        	    ((TabImageView) mView).setImageResource(iconResId);
+            if (iconResId != 0 && (text == null || text.length() == 0)) {
+                mView = new TabImageView(context, null, R.attr.vpiTabPageIndicatorStyle);
+                ((TabImageView) mView).setImageResource(iconResId);
         	} else {
                 mView = new TabTextView(context, null, R.attr.vpiTabPageIndicatorStyle);
                 ((TabTextView) mView).setText(text);
@@ -269,21 +272,22 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
             mView.setOnClickListener(mTabClickListener);
             mView.setFocusable(true);
         }
-        
+
         public View getView() {
             return mView;
         }
     }
-    
+
     private class TabTextView extends TextView {
 
-		public TabTextView(Context context, AttributeSet attrs, int defStyle) {
+        public TabTextView(Context context, AttributeSet attrs, int defStyle) {
 		    super(context, attrs, defStyle);
 		}
 
 		@Override
         public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
             // Re-measure if we went beyond our maximum size.
             if (mMaxTabWidth > 0 && getMeasuredWidth() > mMaxTabWidth) {
                 super.onMeasure(MeasureSpec.makeMeasureSpec(mMaxTabWidth, MeasureSpec.EXACTLY),
@@ -291,16 +295,17 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
             }
         }
     }
-    
+
     private class TabImageView extends ImageView {
 
-		public TabImageView(Context context, AttributeSet attrs, int defStyle) {
+        public TabImageView(Context context, AttributeSet attrs, int defStyle) {
 			super(context, attrs, defStyle);
 		}
 
 		@Override
         public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
             // Re-measure if we went beyond our maximum size.
             if (mMaxTabWidth > 0 && getMeasuredWidth() > mMaxTabWidth) {
                 super.onMeasure(MeasureSpec.makeMeasureSpec(mMaxTabWidth, MeasureSpec.EXACTLY),

--- a/sample/AndroidManifest.xml
+++ b/sample/AndroidManifest.xml
@@ -229,6 +229,15 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".SampleTabsIconOnly"
+            android:label="Tabs/Icon Only"
+            android:theme="@style/Theme.PageIndicatorDefaults">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.jakewharton.android.viewpagerindicator.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".SampleTabsStyled"
             android:label="Tabs/Styled"
             android:theme="@style/StyledIndicators">

--- a/sample/src/com/viewpagerindicator/sample/SampleTabsIconOnly.java
+++ b/sample/src/com/viewpagerindicator/sample/SampleTabsIconOnly.java
@@ -1,0 +1,60 @@
+package com.viewpagerindicator.sample;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+
+import com.viewpagerindicator.IconPagerAdapter;
+import com.viewpagerindicator.TabPageIndicator;
+
+public class SampleTabsIconOnly extends FragmentActivity {
+    private static final int[] ICONS = new int[] {
+        R.drawable.perm_group_calendar,
+        R.drawable.perm_group_camera,
+        R.drawable.perm_group_device_alarms,
+        R.drawable.perm_group_location
+    };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.simple_tabs);
+
+        FragmentPagerAdapter adapter = new GoogleMusicAdapter(getSupportFragmentManager());
+
+        ViewPager pager = (ViewPager)findViewById(R.id.pager);
+        pager.setAdapter(adapter);
+
+        TabPageIndicator indicator = (TabPageIndicator)findViewById(R.id.indicator);
+        indicator.setViewPager(pager);
+    }
+
+    class GoogleMusicAdapter extends FragmentPagerAdapter implements IconPagerAdapter {
+        public GoogleMusicAdapter(FragmentManager fm) {
+            super(fm);
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            return TestFragment.newInstance(getResources().getResourceEntryName(ICONS[position % ICONS.length]));
+        }
+
+        @Override
+        public CharSequence getPageTitle(int position) {
+            return null;
+        }
+
+        @Override
+        public int getCount() {
+          return ICONS.length;
+        }
+
+		@Override
+		public int getIconResId(int index) {
+			return ICONS[index % ICONS.length];
+		}
+    }
+}


### PR DESCRIPTION
(resubmitting on dev branch after reading comments on other pull requests)

I added the ability in TabPageIndicator to use a centered icon in the case where a null or empty title is provided by FragmentPagerAdapter and a resource id is supplied by getIconResId (from IconPagerAdapter interface). This includes a new sample Activity in the Tabs section (Tabs/Icon Only)

![device-2013-01-16-150013](https://f.cloud.github.com/assets/938732/76030/f165fd00-60de-11e2-8815-06a12dbea884.png)

![device-2013-01-16-150020](https://f.cloud.github.com/assets/938732/76031/f62dd682-60de-11e2-8dd0-30ab458d040d.png)
