### PR TITLE
Fix for TitlePageIndicator incomplete animation ("stuck" between tabs).

### DIFF
--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -754,6 +754,11 @@ public class TitlePageIndicator extends View implements PageIndicator {
     public void onPageScrollStateChanged(int state) {
         mScrollState = state;
 
+        if (mPageOffset > 0 && state == ViewPager.SCROLL_STATE_IDLE) {
+            mCurrentPage = mViewPager.getCurrentItem();
+            mPageOffset = 0;
+        }
+
         if (mListener != null) {
             mListener.onPageScrollStateChanged(state);
         }


### PR DESCRIPTION
There are actually two issues:

ViewPager doesn't always emit every onPageScrolled event, so onPageScrollStateChanged(SCROLL_STATE_IDLE) can be called while mPageOffset is still > 0. This issue seems to happen when the UI drops frames.

onPageSelected can be called while scrolling is not idle causing mCurrentPage to not be updated before onPageScrollStateChanged(SCROLL_STATE_IDLE). This happens when calling viewPager.setCurrentItem directly, such as by tapping on another tab.
