### PR TITLE
rename library project artifact id

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -3,7 +3,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>library</artifactId>
+	<artifactId>library-viewpagerindicator</artifactId>
 	<name>Android-ViewPagerIndicator</name>
 	<packaging>apklib</packaging>
 


### PR DESCRIPTION
When importing the project as a maven project in Eclipse, I got a conflicting error that the project name 'library' already exists in my working space. By changing this to a 'unique' artifact id (library-viewpagerindicator) this error has been solved. As I think I'm not the only developer with this problem, I suggest this pull request.
