### PR TITLE
Changes onTouchEvent method to not consume touch events

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,0 +1,35 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:0.4'
+    }
+}
+apply plugin: 'android-library'
+
+dependencies {
+}
+
+android {
+    compileSdkVersion 16
+    buildToolsVersion "16"
+
+    defaultConfig {
+        minSdkVersion 4
+        targetSdkVersion 4
+    }
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+
+        instrumentTest.setRoot('tests')
+    }
+}

--- a/library/project.properties
+++ b/library/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=android-16
+target=android-17

--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -326,12 +326,12 @@ public class CirclePageIndicator extends View implements PageIndicator {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage - 1);
                         }
-                        return false; //here
+                        return false;
                     } else if ((mCurrentPage < count - 1) && (ev.getX() > halfWidth + sixthWidth)) {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage + 1);
                         }
-                        return false;//here
+                        return false;
                     }
                 }
 
@@ -358,7 +358,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
                 break;
         }
 
-        return false;//here
+        return false;
     }
 
     @Override

--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -326,12 +326,12 @@ public class CirclePageIndicator extends View implements PageIndicator {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage - 1);
                         }
-                        return true;
+                        return false; //here
                     } else if ((mCurrentPage < count - 1) && (ev.getX() > halfWidth + sixthWidth)) {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage + 1);
                         }
-                        return true;
+                        return false;//here
                     }
                 }
 
@@ -358,7 +358,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
                 break;
         }
 
-        return true;
+        return false;//here
     }
 
     @Override

--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -326,12 +326,12 @@ public class CirclePageIndicator extends View implements PageIndicator {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage - 1);
                         }
-                        return true;
+                        return false;
                     } else if ((mCurrentPage < count - 1) && (ev.getX() > halfWidth + sixthWidth)) {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage + 1);
                         }
-                        return true;
+                        return false;
                     }
                 }
 
@@ -358,7 +358,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
                 break;
         }
 
-        return true;
+        return false;
     }
 
     @Override

--- a/library/src/com/viewpagerindicator/LinePageIndicator.java
+++ b/library/src/com/viewpagerindicator/LinePageIndicator.java
@@ -238,12 +238,12 @@ public class LinePageIndicator extends View implements PageIndicator {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage - 1);
                         }
-                        return true;
+                        return false;
                     } else if ((mCurrentPage < count - 1) && (ev.getX() > halfWidth + sixthWidth)) {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage + 1);
                         }
-                        return true;
+                        return false;
                     }
                 }
 
@@ -270,7 +270,7 @@ public class LinePageIndicator extends View implements PageIndicator {
                 break;
         }
 
-        return true;
+        return false;
     }
 
     @Override

--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -593,14 +593,14 @@ public class TitlePageIndicator extends View implements PageIndicator {
                             if (action != MotionEvent.ACTION_CANCEL) {
                                 mViewPager.setCurrentItem(mCurrentPage - 1);
                             }
-                            return true;
+                            return false;
                         }
                     } else if (eventX > rightThird) {
                         if (mCurrentPage < count - 1) {
                             if (action != MotionEvent.ACTION_CANCEL) {
                                 mViewPager.setCurrentItem(mCurrentPage + 1);
                             }
-                            return true;
+                            return false;
                         }
                     } else {
                         //Middle third
@@ -633,7 +633,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
                 break;
         }
 
-        return true;
+        return false;
     }
 
     /**

--- a/library/src/com/viewpagerindicator/UnderlinePageIndicator.java
+++ b/library/src/com/viewpagerindicator/UnderlinePageIndicator.java
@@ -226,12 +226,12 @@ public class UnderlinePageIndicator extends View implements PageIndicator {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage - 1);
                         }
-                        return true;
+                        return false;
                     } else if ((mCurrentPage < count - 1) && (ev.getX() > halfWidth + sixthWidth)) {
                         if (action != MotionEvent.ACTION_CANCEL) {
                             mViewPager.setCurrentItem(mCurrentPage + 1);
                         }
-                        return true;
+                        return false;
                     }
                 }
 
@@ -258,7 +258,7 @@ public class UnderlinePageIndicator extends View implements PageIndicator {
                 break;
         }
 
-        return true;
+        return false;
     }
 
     @Override

--- a/sample/project.properties
+++ b/sample/project.properties
@@ -8,5 +8,5 @@
 # project structure.
 
 # Project target.
-target=android-16
+target=android-17
 android.library.reference.1=../library


### PR DESCRIPTION
The indicators consume the touch events, thus making it impossible to receive events up in the hierarchy.
