### PR TITLE
Add extraSpacing attribute to CirclePageIndicator

### DIFF
--- a/library/res/values/vpi__attrs.xml
+++ b/library/res/values/vpi__attrs.xml
@@ -53,6 +53,8 @@
         <attr name="strokeColor" format="color" />
         <!-- Width of the stroke used to draw the circles. -->
         <attr name="strokeWidth" />
+        <!-- Extra space between the circles. -->
+        <attr name="extraSpacing" format="dimension" />
         <!-- View background -->
         <attr name="android:background"/>
     </declare-styleable>

--- a/library/res/values/vpi__defaults.xml
+++ b/library/res/values/vpi__defaults.xml
@@ -23,6 +23,7 @@
     <bool name="default_circle_indicator_snap">false</bool>
     <color name="default_circle_indicator_stroke_color">#FFDDDDDD</color>
     <dimen name="default_circle_indicator_stroke_width">1dp</dimen>
+    <dimen name="default_circle_indicator_extra_spacing">0dp</dimen>
 
     <dimen name="default_line_indicator_line_width">12dp</dimen>
     <dimen name="default_line_indicator_gap_width">4dp</dimen>

--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -62,6 +62,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
     private float mLastMotionX = -1;
     private int mActivePointerId = INVALID_POINTER;
     private boolean mIsDragging;
+    private float mExtraSpacing;
 
 
     public CirclePageIndicator(Context context) {
@@ -82,6 +83,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
         final int defaultFillColor = res.getColor(R.color.default_circle_indicator_fill_color);
         final int defaultOrientation = res.getInteger(R.integer.default_circle_indicator_orientation);
         final int defaultStrokeColor = res.getColor(R.color.default_circle_indicator_stroke_color);
+        final float defaultExtraSpacing = res.getDimension(R.dimen.default_circle_indicator_extra_spacing);
         final float defaultStrokeWidth = res.getDimension(R.dimen.default_circle_indicator_stroke_width);
         final float defaultRadius = res.getDimension(R.dimen.default_circle_indicator_radius);
         final boolean defaultCentered = res.getBoolean(R.bool.default_circle_indicator_centered);
@@ -101,6 +103,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
         mPaintFill.setColor(a.getColor(R.styleable.CirclePageIndicator_fillColor, defaultFillColor));
         mRadius = a.getDimension(R.styleable.CirclePageIndicator_radius, defaultRadius);
         mSnap = a.getBoolean(R.styleable.CirclePageIndicator_snap, defaultSnap);
+        mExtraSpacing = a.getDimension(R.styleable.CirclePageIndicator_extraSpacing, defaultExtraSpacing);
 
         Drawable background = a.getDrawable(R.styleable.CirclePageIndicator_android_background);
         if (background != null) {
@@ -194,6 +197,10 @@ public class CirclePageIndicator extends View implements PageIndicator {
         return mSnap;
     }
 
+    public void setExtraSpacing(float extraSpacing) {
+        mExtraSpacing = extraSpacing;
+    }
+
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
@@ -227,7 +234,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
             shortPaddingBefore = getPaddingLeft();
         }
 
-        final float threeRadius = mRadius * 3;
+        final float threeRadius = mRadius * 3 + mExtraSpacing;
         final float shortOffset = shortPaddingBefore + mRadius;
         float longOffset = longPaddingBefore + mRadius;
         if (mCentered) {
@@ -469,7 +476,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
             //Calculate the width according the views count
             final int count = mViewPager.getAdapter().getCount();
             result = (int)(getPaddingLeft() + getPaddingRight()
-                    + (count * 2 * mRadius) + (count - 1) * mRadius + 1);
+                    + (count * 2 * mRadius) + (count - 1) * (mRadius + mExtraSpacing) + 1);
             //Respect AT_MOST value if that was what is called for by measureSpec
             if (specMode == MeasureSpec.AT_MOST) {
                 result = Math.min(result, specSize);


### PR DESCRIPTION
The `extraSpacing` XML attribute specifies additional spacing between the circles,
also configurable via the `setExtraSpacing(float)` method.
