### PR TITLE
Added ability to set icon location for tabs in TabPageIndicator

### DIFF
--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -74,6 +74,24 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
 
     private OnTabReselectedListener mTabReselectedListener;
 
+    /**
+    * Stores the location of the tab icon
+    */
+    private int location;
+
+    /**
+    * Constants to improve readability - no magic numbers.
+    */
+    public final static int LOCATION_LEFT =0;
+    public final static int LOCATION_UP =1;
+    public final static int LOCATION_RIGHT = 2;
+    public final static int LOCATION_BOTTOM =3;
+
+    /**
+    * Used to store the icon.
+    */
+    private int [] drawables = new int [4];
+
     public TabPageIndicator(Context context) {
         this(context, null);
     }
@@ -149,6 +167,10 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
         }
     }
 
+    public void setTabIconLocation (int location){
+       this.location = location;
+    }
+
     private void addTab(int index, CharSequence text, int iconResId) {
         final TabView tabView = new TabView(getContext());
         tabView.mIndex = index;
@@ -157,7 +179,8 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
         tabView.setText(text);
 
         if (iconResId != 0) {
-            tabView.setCompoundDrawablesWithIntrinsicBounds(iconResId, 0, 0, 0);
+            drawables [location] = iconResId;
+            tabView.setCompoundDrawablesWithIntrinsicBounds(drawables[0], drawables[1], drawables[2], drawables[3]);
         }
 
         mTabLayout.addView(tabView, new LinearLayout.LayoutParams(0, MATCH_PARENT, 1));

--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -74,18 +74,19 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
 
     private OnTabReselectedListener mTabReselectedListener;
 
-    /**
-    * Stores the location of the tab icon
-    */
-    private int location;
 
     /**
     * Constants to improve readability - no magic numbers.
     */
     public final static int LOCATION_LEFT =0;
-    public final static int LOCATION_UP =1;
+    public final static int LOCATION_UP = 1;
     public final static int LOCATION_RIGHT = 2;
     public final static int LOCATION_BOTTOM =3;
+
+    /**
+    * Stores the location of the tab icon
+    */
+    private int location = LOCATION_LEFT;
 
     /**
     * Used to store the icon.
@@ -167,8 +168,10 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
         }
     }
 
-    public void setTabIconLocation (int location){
-       this.location = location;
+    public void setTabIconLocation (int newLocation){
+        this.location = newLocation;
+        if (location > LOCATION_BOTTOM || location < LOCATION_LEFT)
+            throw new IllegalArgumentException ("Invalid location");
     }
 
     private void addTab(int index, CharSequence text, int iconResId) {

--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -93,6 +93,11 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
     */
     private int [] drawables = new int [4];
 
+    /**
+     * Holds the value used by setCompoundDrawablesWithIntrinsicBounds used to denote no icon.
+     */
+    private static int NO_ICON = 0;
+    
     public TabPageIndicator(Context context) {
         this(context, null);
     }
@@ -169,9 +174,12 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
     }
 
     public void setTabIconLocation (int newLocation){
-        this.location = newLocation;
         if (location > LOCATION_BOTTOM || location < LOCATION_LEFT)
             throw new IllegalArgumentException ("Invalid location");
+        this.location = newLocation;
+        for (int x = 0; x < drawables.length;x++){
+        	drawables [x] = NO_ICON;
+        }
     }
 
     private void addTab(int index, CharSequence text, int iconResId) {

--- a/sample/src/com/viewpagerindicator/sample/SampleTabsWithIcons.java
+++ b/sample/src/com/viewpagerindicator/sample/SampleTabsWithIcons.java
@@ -29,6 +29,7 @@ public class SampleTabsWithIcons extends FragmentActivity {
         pager.setAdapter(adapter);
 
         TabPageIndicator indicator = (TabPageIndicator)findViewById(R.id.indicator);
+        indicator.setTabIconLocation (TabPageIndicator.LOCATION_UP);
         indicator.setViewPager(pager);
     }
 


### PR DESCRIPTION
Implementations should use

``` java
indicator.setTabIconLocation (TabPageIndicator.LOCATION_CONST);
```

`LOCATION_CONST` is one of 4 location constants defined in `TabPageIndicator`

If no location is specified, the icon will be shown on the left.
