### PR TITLE
Add option to specify spacing between circle page indicators.

### DIFF
--- a/library/res/values/vpi__attrs.xml
+++ b/library/res/values/vpi__attrs.xml
@@ -37,6 +37,8 @@
     <attr name="unselectedColor" format="color" />
 
     <declare-styleable name="CirclePageIndicator">
+        <!-- Spacing between the page indicators -->
+        <attr name="itemSpacing" format="dimension"/>
         <!-- Whether or not the indicators should be centered. -->
         <attr name="centered" />
         <!-- Color of the filled circle that represents the current page. -->

--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -53,6 +53,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
     private int mCurrentPage;
     private int mSnapPage;
     private float mPageOffset;
+    private float mIndicatorSpacing;
     private int mScrollState;
     private int mOrientation;
     private boolean mCentered;
@@ -86,10 +87,12 @@ public class CirclePageIndicator extends View implements PageIndicator {
         final float defaultRadius = res.getDimension(R.dimen.default_circle_indicator_radius);
         final boolean defaultCentered = res.getBoolean(R.bool.default_circle_indicator_centered);
         final boolean defaultSnap = res.getBoolean(R.bool.default_circle_indicator_snap);
+        final float defaultSpacing = 3 * defaultRadius;
 
         //Retrieve styles attributes
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.CirclePageIndicator, defStyle, 0);
 
+        mIndicatorSpacing = a.getDimension(R.styleable.CirclePageIndicator_itemSpacing, defaultSpacing);
         mCentered = a.getBoolean(R.styleable.CirclePageIndicator_centered, defaultCentered);
         mOrientation = a.getInt(R.styleable.CirclePageIndicator_android_orientation, defaultOrientation);
         mPaintPageFill.setStyle(Style.FILL);
@@ -227,11 +230,10 @@ public class CirclePageIndicator extends View implements PageIndicator {
             shortPaddingBefore = getPaddingLeft();
         }
 
-        final float threeRadius = mRadius * 3;
         final float shortOffset = shortPaddingBefore + mRadius;
         float longOffset = longPaddingBefore + mRadius;
         if (mCentered) {
-            longOffset += ((longSize - longPaddingBefore - longPaddingAfter) / 2.0f) - ((count * threeRadius) / 2.0f);
+            longOffset += ((longSize - longPaddingBefore - longPaddingAfter) / 2.0f) - (((count - 1) * mIndicatorSpacing) / 2.0f) - mRadius;
         }
 
         float dX;
@@ -244,7 +246,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
 
         //Draw stroked circles
         for (int iLoop = 0; iLoop < count; iLoop++) {
-            float drawLong = longOffset + (iLoop * threeRadius);
+            float drawLong = longOffset + (iLoop * mIndicatorSpacing);
             if (mOrientation == HORIZONTAL) {
                 dX = drawLong;
                 dY = shortOffset;
@@ -264,9 +266,9 @@ public class CirclePageIndicator extends View implements PageIndicator {
         }
 
         //Draw the filled circle according to the current scroll
-        float cx = (mSnap ? mSnapPage : mCurrentPage) * threeRadius;
+        float cx = (mSnap ? mSnapPage : mCurrentPage) * mIndicatorSpacing;
         if (!mSnap) {
-            cx += mPageOffset * threeRadius;
+            cx += mPageOffset * mIndicatorSpacing;
         }
         if (mOrientation == HORIZONTAL) {
             dX = longOffset + cx;

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <android.platform>16</android.platform>
         <android.support.version>r7</android.support.version>
 
-        <android-maven.version>3.3.0</android-maven.version>
+        <android-maven.version>3.6.1</android-maven.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
We added an option to the style named "itemSpacing" that specifies the center-to-center distance between the circle page indicators.  If unspecified, the spacing defaults to 3 times the radius as before.
