### PR TITLE
fixed NullPointerException in onDraw

### DIFF
--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -198,7 +198,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        if (mViewPager == null) {
+        if (mViewPager == null || mViewPager.getAdapter() == null) {
             return;
         }
         final int count = mViewPager.getAdapter().getCount();

--- a/library/src/com/viewpagerindicator/LinePageIndicator.java
+++ b/library/src/com/viewpagerindicator/LinePageIndicator.java
@@ -157,7 +157,7 @@ public class LinePageIndicator extends View implements PageIndicator {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        if (mViewPager == null) {
+        if (mViewPager == null || mViewPager.getAdapter() == null) {
             return;
         }
         final int count = mViewPager.getAdapter().getCount();

--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -354,7 +354,7 @@ public class TitlePageIndicator extends View implements PageIndicator {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        if (mViewPager == null) {
+        if (mViewPager == null || mViewPager.getAdapter() == null) {
             return;
         }
         final int count = mViewPager.getAdapter().getCount();

--- a/library/src/com/viewpagerindicator/UnderlinePageIndicator.java
+++ b/library/src/com/viewpagerindicator/UnderlinePageIndicator.java
@@ -156,7 +156,7 @@ public class UnderlinePageIndicator extends View implements PageIndicator {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        if (mViewPager == null) {
+        if (mViewPager == null || mViewPager.getAdapter() == null) {
             return;
         }
         final int count = mViewPager.getAdapter().getCount();


### PR DESCRIPTION
Fixing NPE that happened after finish() was called on a FragmentActivity. The viewpager in the fragment appeared to be without adapter in the moment causing a crash in onDraw.
