### PR TITLE
Fix for NullPointerException via TitlePageIndicator.onTouchEvent - fakeD...

### DIFF
--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -568,10 +568,6 @@ public class TitlePageIndicator extends View implements PageIndicator {
                 }
 
                 if (mIsDragging) {
-                    if (mViewPager.isFakeDragging()) {
-                        mViewPager.endFakeDrag();
-                    }
-
                     mLastMotionX = x;
                     if (mViewPager.beginFakeDrag()) {
                         mViewPager.fakeDragBy(deltaX);

--- a/library/src/com/viewpagerindicator/TitlePageIndicator.java
+++ b/library/src/com/viewpagerindicator/TitlePageIndicator.java
@@ -568,8 +568,12 @@ public class TitlePageIndicator extends View implements PageIndicator {
                 }
 
                 if (mIsDragging) {
+                    if (mViewPager.isFakeDragging()) {
+                        mViewPager.endFakeDrag();
+                    }
+
                     mLastMotionX = x;
-                    if (mViewPager.isFakeDragging() || mViewPager.beginFakeDrag()) {
+                    if (mViewPager.beginFakeDrag()) {
                         mViewPager.fakeDragBy(deltaX);
                     }
                 }


### PR DESCRIPTION
...ragBy

Possible fix for: https://github.com/JakeWharton/Android-ViewPagerIndicator/issues/72
This is our top crash, affecting about 40k users. What happens is that the mVelocityTracker in ViewPager is null, resulting in a NPE. mVelocityTracker is set to null in endDrag() which is called from other places other than endFakeDrag(). 

My fix calls every time beginFakeDrag() before fake dragging, to be sure that a fresh fake drag movement is started every time, and mVelocityTracker is not null (because from docs I understand the correct flow for doing a fake drag is beginFakeDrag() -> fakeDragBy() -> endFakeDrag()).

Per beginFakeDrag java docs:

```
A fake drag can be useful if you want to synchronize the motion of the ViewPager
     * with the touch scrolling of another view, while still letting the ViewPager
     * control the snapping motion and fling behavior. (e.g. parallax-scrolling tabs.)
     * Call {@link #fakeDragBy(float)} to simulate the actual drag motion. Call
     * {@link #endFakeDrag()} to complete the fake drag and fling as necessary.
```
