### PR TITLE
fixing the CirclePageIndicator's chopped circles

### DIFF
--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -228,8 +228,8 @@ public class CirclePageIndicator extends View implements PageIndicator {
         }
 
         final float threeRadius = mRadius * 3;
-        final float shortOffset = shortPaddingBefore + mRadius;
-        float longOffset = longPaddingBefore + mRadius;
+        final float shortOffset = shortPaddingBefore + mRadius + 1;
+        float longOffset = longPaddingBefore + mRadius + 1;
         if (mCentered) {
             longOffset += ((longSize - longPaddingBefore - longPaddingAfter) / 2.0f) - ((count * threeRadius) / 2.0f);
         }
@@ -469,7 +469,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
             //Calculate the width according the views count
             final int count = mViewPager.getAdapter().getCount();
             result = (int)(getPaddingLeft() + getPaddingRight()
-                    + (count * 2 * mRadius) + (count - 1) * mRadius + 1);
+                    + (count * 2 * mRadius) + (count - 1) * mRadius + 2);
             //Respect AT_MOST value if that was what is called for by measureSpec
             if (specMode == MeasureSpec.AT_MOST) {
                 result = Math.min(result, specSize);
@@ -495,7 +495,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
             result = specSize;
         } else {
             //Measure the height
-            result = (int)(2 * mRadius + getPaddingTop() + getPaddingBottom() + 1);
+            result = (int)(2 * mRadius + getPaddingTop() + getPaddingBottom() + 2);
             //Respect AT_MOST value if that was what is called for by measureSpec
             if (specMode == MeasureSpec.AT_MOST) {
                 result = Math.min(result, specSize);


### PR DESCRIPTION
When I used the `CirclePageIndicator`, I gave it a bigger radius, set the height to `wrap_contents` and experienced that the circles' top has 1px chopped. I modified it to measure the view 1 whateverunit taller, and broader, and start drawing with one more whateverunit offset.

Please review.

Another solution would be to draw differently, that might be better.
