### PR TITLE
Circles' stroke is painted inside the radius, not centered on it

### DIFF
--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -259,7 +259,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
 
             // Only paint stroke if a stroke width was non-zero
             if (pageFillRadius != mRadius) {
-                canvas.drawCircle(dX, dY, mRadius, mPaintStroke);
+                canvas.drawCircle(dX + mPaintStroke.getStrokeWidth() / 2.0f, dY + mPaintStroke.getStrokeWidth() / 2.0f, mRadius - mPaintStroke.getStrokeWidth(), mPaintStroke);
             }
         }
 


### PR DESCRIPTION
I opened  #306, but soon I realized what is the real cause of that bug. This PR calculates different values for `drawCircle` to make it behave as `drawCircle` would paint the stroke inside the radius, and not centered on it.
