### PR TITLE
Simpler setViewPager(viewPager, initialPosition)

### DIFF
--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -230,8 +230,8 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
 
     @Override
     public void setViewPager(ViewPager view, int initialPosition) {
+        mSelectedTabIndex = initialPosition;
         setViewPager(view);
-        setCurrentItem(initialPosition);
     }
 
     @Override


### PR DESCRIPTION
[`setViewPager(view)`](https://github.com/JakeWharton/Android-ViewPagerIndicator/blob/dev/library/src/com/viewpagerindicator/TabPageIndicator.java#L233) has called [`setCurrentItem(mSelectedTabIndex)`](https://github.com/JakeWharton/Android-ViewPagerIndicator/blob/dev/library/src/com/viewpagerindicator/TabPageIndicator.java#L227), so we don't have to do this again.
