### PR TITLE
Fix crash in layout editor due to ViewPager not set in onMeasure()

### DIFF
--- a/library/src/com/viewpagerindicator/TabPageIndicator.java
+++ b/library/src/com/viewpagerindicator/TabPageIndicator.java
@@ -111,7 +111,7 @@ public class TabPageIndicator extends HorizontalScrollView implements PageIndica
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         final int newWidth = getMeasuredWidth();
 
-        if (lockedExpanded && oldWidth != newWidth) {
+        if (!isInEditMode() && lockedExpanded && oldWidth != newWidth) {
             // Recenter the tab display if we're at a new (scrollable) size.
             setCurrentItem(mSelectedTabIndex);
         }


### PR DESCRIPTION
The call to setCurrentItem() in onMeasure() throws an IllegalStateException as the ViewPager is null in editor. This commit fixes this by calling setCurrentItem() only when not in edit mode.
