### PR TITLE
Add spacing attribute to CirclePageIndicator

### DIFF
--- a/library/res/values/vpi__attrs.xml
+++ b/library/res/values/vpi__attrs.xml
@@ -45,8 +45,10 @@
         <attr name="pageColor" format="color" />
         <!-- Orientation of the indicator. -->
         <attr name="android:orientation"/>
-        <!-- Radius of the circles. This is also the spacing between circles. -->
+        <!-- Radius of the circles. -->
         <attr name="radius" format="dimension" />
+        <!-- Spacing between two circles. -->
+        <attr name="spacing" format="dimension" />
         <!-- Whether or not the selected indicator snaps to the circles. -->
         <attr name="snap" format="boolean" />
         <!-- Color of the open circles. -->

--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -45,6 +45,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
     private static final int INVALID_POINTER = -1;
 
     private float mRadius;
+    private float mSpacing;
     private final Paint mPaintPageFill = new Paint(ANTI_ALIAS_FLAG);
     private final Paint mPaintStroke = new Paint(ANTI_ALIAS_FLAG);
     private final Paint mPaintFill = new Paint(ANTI_ALIAS_FLAG);
@@ -100,6 +101,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
         mPaintFill.setStyle(Style.FILL);
         mPaintFill.setColor(a.getColor(R.styleable.CirclePageIndicator_fillColor, defaultFillColor));
         mRadius = a.getDimension(R.styleable.CirclePageIndicator_radius, defaultRadius);
+        mSpacing = a.getDimension(R.styleable.CirclePageIndicator_spacing, mRadius);
         mSnap = a.getBoolean(R.styleable.CirclePageIndicator_snap, defaultSnap);
 
         Drawable background = a.getDrawable(R.styleable.CirclePageIndicator_android_background);
@@ -227,11 +229,11 @@ public class CirclePageIndicator extends View implements PageIndicator {
             shortPaddingBefore = getPaddingLeft();
         }
 
-        final float threeRadius = mRadius * 3;
+        final float offsetDiff = mRadius * 2 + mSpacing;
         final float shortOffset = shortPaddingBefore + mRadius;
         float longOffset = longPaddingBefore + mRadius;
         if (mCentered) {
-            longOffset += ((longSize - longPaddingBefore - longPaddingAfter) / 2.0f) - ((count * threeRadius) / 2.0f);
+            longOffset += ((longSize - longPaddingBefore - longPaddingAfter) / 2.0f) - (((count - 1) * offsetDiff + mRadius * 2) / 2.0f);
         }
 
         float dX;
@@ -244,7 +246,7 @@ public class CirclePageIndicator extends View implements PageIndicator {
 
         //Draw stroked circles
         for (int iLoop = 0; iLoop < count; iLoop++) {
-            float drawLong = longOffset + (iLoop * threeRadius);
+            float drawLong = longOffset + (iLoop * offsetDiff);
             if (mOrientation == HORIZONTAL) {
                 dX = drawLong;
                 dY = shortOffset;
@@ -264,9 +266,9 @@ public class CirclePageIndicator extends View implements PageIndicator {
         }
 
         //Draw the filled circle according to the current scroll
-        float cx = (mSnap ? mSnapPage : mCurrentPage) * threeRadius;
+        float cx = (mSnap ? mSnapPage : mCurrentPage) * offsetDiff;
         if (!mSnap) {
-            cx += mPageOffset * threeRadius;
+            cx += mPageOffset * offsetDiff;
         }
         if (mOrientation == HORIZONTAL) {
             dX = longOffset + cx;

--- a/library/src/com/viewpagerindicator/CirclePageIndicator.java
+++ b/library/src/com/viewpagerindicator/CirclePageIndicator.java
@@ -187,6 +187,15 @@ public class CirclePageIndicator extends View implements PageIndicator {
         return mRadius;
     }
 
+    public void setSpacing(float spacing) {
+        mSpacing = spacing;
+        invalidate();
+    }
+
+    public float getSpacing() {
+        return mSpacing;
+    }
+
     public void setSnap(boolean snap) {
         mSnap = snap;
         invalidate();


### PR DESCRIPTION
In current implement the spacing between two circle is 2 \* radius and we can not customize this value. This pull request add spacing attribute, so we can customize it now. 
