### PR TITLE
Added minimal support for Gradle, and thus compiling with Android Studio.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #Android generated
 bin
 gen
+build
 
 #Eclipse
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin
 gen
 build
+.gradle
 
 #Eclipse
 .project

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,0 +1,35 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 16
+    buildToolsVersion '19.1.0'
+
+    defaultConfig {
+        minSdkVersion 4
+        targetSdkVersion 4
+    }
+
+    sourceSets {
+        main {
+            manifest {
+                srcFile 'AndroidManifest.xml'
+            }
+            java {
+                srcDir 'src'
+            }
+            res {
+                srcDir 'res'
+            }
+            assets {
+                srcDir 'assets'
+            }
+            resources {
+                srcDir 'src'
+            }
+        }
+    }
+}
+
+dependencies {
+    compile 'com.android.support:support-v4:18.+'
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -30,6 +30,31 @@ android {
     }
 }
 
+android.libraryVariants.all  { variant ->      
+    def name = variant.buildType.name      
+    if (!name.equals("debug")) {      
+        def task = project.tasks.create  "jar${name.capitalize()}", Jar      
+        task.dependsOn variant.javaCompile      
+        task.from  variant.javaCompile.destinationDir      
+        artifacts.add('archives', task);      
+    }      
+}
+
 dependencies {
     compile 'com.android.support:support-v4:18.+'
+}
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.3.0'
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+    }
 }

--- a/library/settings.gradle
+++ b/library/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'Android-ViewPagerIndicator'


### PR DESCRIPTION
It's simpler now to use the original sources from Github, just clone the repo and add two lines in your project's `settings.gradle` (assuming you cloned the repo at the same directory level where `app/` directory is):

```
include 'ViewPagerIndicator'
project(':ViewPagerIndicator').projectDir = new File('ViewPagerIndicator/library')
```

and in your `app/build.gradle`'s dependencies:

`compile project(':ViewPagerIndicator')`
